### PR TITLE
add sfc_tmp node for temperature sensor

### DIFF
--- a/arch/riscv/dts/starfive_vic7100_evb.dts
+++ b/arch/riscv/dts/starfive_vic7100_evb.dts
@@ -522,5 +522,12 @@
 			/*fixed-emmc-driver-type;*/
 			post-power-on-delay-ms = <200>;
 		};
+		sfc_tmp:tmpsensor@124A0000 {
+			compatible = "sfc,tempsensor";
+			reg = <0x0 0x124A0000 0x0 0x1000>;
+			interrupt-parent = <&plic>;
+			interrupts = <122>;
+			status = "okay";
+		};
 	};
 };


### PR DESCRIPTION
Based on sfc_tmp from starfive_vic7100_evb.dts in @tekkamanninja branch Fedora_VIC_7100_2021.04
```
# dmesg |grep sfc_temp
[    3.770961] sfc_temp_sensor 124a0000.tmpsensor: probe
# cat /sys/bus/platform/drivers/sfc_temp_sensor/124a0000.tmpsensor/temp1_input 
40.84
```
This depends on kernel config PR from @mike-scott in:
https://github.com/starfive-tech/freelight-u-sdk/pull/16